### PR TITLE
Fix DS1307 NVRAM multibyte read to use actual size.

### DIFF
--- a/src/DS1307.cpp
+++ b/src/DS1307.cpp
@@ -629,7 +629,7 @@ void NVRAM::read(uint8_t address, uint8_t* buf, uint8_t size)
 	Wire.beginTransmission(DS1307_ADDR);
 	Wire.write(addrByte);
 	Wire.endTransmission();
-	Wire.requestFrom(DS1307_ADDR, 9);
+	Wire.requestFrom(DS1307_ADDR, size);
 	for (uint8_t pos = 0; pos < size; ++pos)
 	{
 		buf[pos] = Wire.read();


### PR DESCRIPTION
Multibyte read read nine bytes regardless of desired size.

It also appears that the multibyte read and write do not work correctly if the amount read/written exceeds 32 bytes.  